### PR TITLE
Fix for "authentication credentials" error, + updated README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ $rv = $r->addVideo(
     1,                                  //season
     1,                                  //current series
     2,                                  //type of video
-    154466                              //id in your CMS
+    154466,                             //id in your CMS
+    false                               //adult
 );
 
 //if request will success returned array of video with rutube id.

--- a/rutubex.php
+++ b/rutubex.php
@@ -24,7 +24,7 @@ class rutubex {
             if (is_array($auth)) {
                 $t = $this->send('POST', '/accounts/token_auth/', $auth);
                 if (!empty($t)) {
-                    self::$token = $t->token;
+                    self::$token=$t['token'];
                 }
             } elseif(is_string($auth)) {
                 self::$token = $auth;


### PR DESCRIPTION
Good day, Ruslan!
I have provided a fix for "authentication credentials" error,
which happens when you use login+password instead of token :

array(1) {
  ["detail"]=>
  string(45) "Authentication credentials were not provided."
}

(you already did this fix in the past, but it didn't appear at the latest version of rutubex.php

Also, I have updated an example at README file
( addVideo function requires a new argument, "adult" )

Thank you for your hard work, I admire you
